### PR TITLE
Align emojis in feedback selections

### DIFF
--- a/src/content/oskarTexts.coffee
+++ b/src/content/oskarTexts.coffee
@@ -26,11 +26,11 @@ OskarTexts =
       "Good morning {0}! Hope you\'re well rested. What\'s your status for today on a scale from 1 to 5?\n",
       "Nice to see you, {0}, Wanna tell me how you feel? A number between 1 and 5 is enough. \n"
     ]
-    selection: "5) Awesome :heart_eyes_cat:\n
-                4) Really good :smile:\n
-                3) Alright :neutral_face:\n
-                2) A bit down :pensive:\n
-                1) Pretty bad :tired_face:\n"
+    selection: "5) :heart_eyes_cat: Awesome\n
+                4) :smile: Really good\n
+                3) :neutral_face: Alright\n
+                2) :pensive: A bit down\n
+                1) :tired_face: Pretty bad\n"
     options: [
       "Hey, didn't you see my last message? It'll only take a second of your time to tell me how you're doing ;)"
       "Hellooooo, what's up? Do you want to ignore me? Just give me a number between 1 and 5 and I'll not bother you any longer."


### PR DESCRIPTION
| before | after |
| -------- | ------ |
| ![screen shot 2015-07-07 at 12 08 20](https://cloud.githubusercontent.com/assets/938453/8538573/f886ace6-24a0-11e5-900b-e55330b673b8.png) | <img width="126" alt="screen shot 2015-07-07 at 12 06 39" src="https://cloud.githubusercontent.com/assets/938453/8538568/d974bfb4-24a0-11e5-89a1-0b1fb9c1ce4c.png"> | 

----

Could potentially add some spacing/whitespace between emoji and text, but I'll let that to you guys.

Next feature: support for reporting feedback with an emoji as well :joy: 