### PR TITLE
Allow app to run locally using coffeescript 

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: coffee src/index.coffee
+web: node_modules/.bin/coffee src/index.coffee

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ See the following instructions if you set up Oskar for the first time.
 
 ###Prerequisites:
 
-* [Node.js](https://nodejs.org/download/): 
-* [Foreman](https://github.com/ddollar/foreman)
+* [Node.js](https://nodejs.org/download/):
+* [Heroku Toolbelt](https://toolbelt.heroku.com/) so that we can use [Heroku Local](https://devcenter.heroku.com/articles/heroku-local)
 * MongoDB: Full instructions are [here](http://docs.mongodb.org/manual/installation/):
 
 You might find this helpful, if you're setting up MongoDB for the first time:
@@ -87,12 +87,12 @@ You might find this helpful, if you're setting up MongoDB for the first time:
 
     # will start MongoDB on port 27071 and initialise the database
     $ mongod
-    
+
     # Install the dependencies
     $ npm install
-    
-    # Start the app using Heroku Foreman
-    $ foreman start web
+
+    # Start the app using Heroku Local
+    $ heroku local
 
 You can then view the app at [http://localhost:5000](http://localhost:5000)
 


### PR DESCRIPTION
In reference to #24, I needed to make a change to the `procfile` in order to get `heroku local` to run. With this change, it worked okay.

Travis seems happy enough with the build. @marcelkalveram perhaps you'll want to give this a go locally and see if you're happy with it. I'm not sure it it'll break the live app when it deploys: I hope not!

Note: the change is based on a suggestion [here](http://stackoverflow.com/questions/6356267/can-i-run-coffeescript-in-heroku#comment29277788_7407261) about better ways to bring `node-coffee` into Heroku apps that need to run locally.