### PR TITLE
Fixes on index and user status page

### DIFF
--- a/src/modules/routes.coffee
+++ b/src/modules/routes.coffee
@@ -66,6 +66,8 @@ routes = (app, mongo, slack) ->
         graphData = data.feedback.map (row) ->
           return [row.timestamp, parseInt(row.status)]
         userData.status = data.feedback[data.feedback.length - 1]
+        userData.date = new Date userData.status.timestamp
+        userData.statusString = OskarTexts.statusText[userData.status.status]
 
       res.render('pages/status', { userData: userData, graphData: JSON.stringify(graphData) })
 

--- a/src/views/pages/index.ejs
+++ b/src/views/pages/index.ejs
@@ -35,7 +35,7 @@
 
                         <!-- User -->
                         <h2 class="post-listing__listing-item__entry-title entry-title">
-                          <%= user.profile.first_name %> <% if(statuses[user.id] && statuses[user.id].status) {%>
+                          <%= user.profile.first_name || user.name %> <% if(statuses[user.id] && statuses[user.id].status) {%>
                             is feeling  <span class="status-<%= statuses[user.id].status %>"><%= statuses[user.id].statusString %></span>
                           <% } else { %>
                             hasn't submitted any status yet

--- a/src/views/pages/status.ejs
+++ b/src/views/pages/status.ejs
@@ -21,7 +21,7 @@
               <% } %>
               <h2 class="post-listing__listing-item__entry-title entry-title">
                 <% if (userData.status) { %>
-                  <%= userData.real_name %> is feeling <% if(userData && userData.status) {%>
+                  <%= userData.real_name || userData.name %> is feeling <% if(userData && userData.status) {%>
                   <span class="status-<%= userData.status.status %>"><%= userData.statusString %></span>
                   <% } %>
                 <% } else { %>


### PR DESCRIPTION
This pull request contains two fixes:
1) sometimes users on slack don't have a full name; now the webui will show the username when the name is not available;
2) when a user had only the "feedback" property we were setting `status`, but not `date` nor `statusString`; this means we were showing a fancy chart, but the top-most part of the status page was still saying "It will show up here once user has onboarded".