### PR TITLE
fix slackClient test relying on old profile fields

### DIFF
--- a/test/slackClient.coffee
+++ b/test/slackClient.coffee
@@ -55,8 +55,8 @@ describe 'SlackClient', ->
       it 'should get a user', ->
         user = slackClient.getUser userIds[0]
         user.name.should.be.type 'string'
-        user.profile.first_name.should.be.type 'string'
-        user.profile.last_name.should.be.type 'string'
+        user.profile.real_name.should.be.type 'string'
+        user.profile.display_name.should.be.type 'string'
 
     describe 'PublicMethodsFeedbackMessage', ->
 


### PR DESCRIPTION
I was trying to get the tests to run locally with a new test-instance of a Slack workspace. New(ish) users don't have a first_name and last_name—though slackbot still does, that plucky bot—swapped with real_name and display_name.